### PR TITLE
Replaced batch operations in updateWithBrokerData 

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -298,17 +298,18 @@ function updateWithBrokerData (that, client, packet, cb) {
       return
     }
 
-    var batch = that._db.batch()
-
     if (decoded.messageId > 0) {
-      batch.del(OUTGOINGID + client.id + ':' + decoded.messageId)
+      that._db.del(OUTGOINGID + client.id + ':' + decoded.messageId)
     }
 
-    batch.put(postkey, packet, dbopts)
-    batch.put(prekey, packet, dbopts)
-
-    batch.write(function (err) {
-      cb(err, client, packet)
+    that._db.put(postkey, packet, dbopts, function (err) {
+      if (err) {
+        cb(err, client, packet)
+      } else {
+        that._db.put(prekey, packet, dbopts, function (err) {
+          cb(err, client, packet)
+        })
+      }
     })
   })
 }

--- a/test.js
+++ b/test.js
@@ -48,3 +48,43 @@ test('restore', function (t) {
     })
   })
 })
+
+test('outgoing update after enqueuing a possible offline message', function (t) {
+  var db = memdb()
+  var instance = persistence(db)
+  var client = {
+    clientId: 'abcde'
+  }
+
+  var client1 = {
+    id: 'abcde'
+  }
+
+  var packet = {
+    cmd: 'publish',
+    brokerId: 'adasdasd',
+    brokerCounter: 0,
+    topic: 'test',
+    payload: 'Return of the Jedi',
+    messageId: 7
+  }
+
+  var updatePacket = {
+    cmd: 'pubrel',
+    messageId: 7
+  }
+  
+  // Enqueue an offline packet
+  instance.outgoingEnqueue(client, packet, function (err, packet1) {
+    t.error(err)
+    // When the client comes back online, aedes calls emptyQueue which calls outgoingUpdate
+    instance.outgoingUpdate(client1, packet, function (err, client, packet) {
+      t.notOk(err, 'no error')
+      // When pubrel is published, outgoingUpdate is called again without the broker Id
+      instance.outgoingUpdate(client, updatePacket, function (err, client, packet) {
+        t.notOk(err, 'no error')
+        instance.destroy(t.end.bind(t))
+      })
+    })
+  })
+})

--- a/test.js
+++ b/test.js
@@ -73,7 +73,6 @@ test('outgoing update after enqueuing a possible offline message', function (t) 
     cmd: 'pubrel',
     messageId: 7
   }
-  
   // Enqueue an offline packet
   instance.outgoingEnqueue(client, packet, function (err, packet1) {
     t.error(err)


### PR DESCRIPTION
Batch operations in updateWithBrokerData causes problems when emptyQueue is called. It pumps inconsistent data causing the error mentioned in issue #14. To overcome this issue, batch operations are replaced by normal get and put database operations.