### PR TITLE
chore: update dependencies to latest (exept tape)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,22 +45,21 @@
   },
   "homepage": "https://github.com/mcollina/aedes-persistence-level#readme",
   "devDependencies": {
-    "aedes": "^0.42.6",
-    "aedes-persistence": "^8.1.1",
+    "aedes": "^0.46.3",
+    "aedes-persistence": "^8.1.3",
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
     "level": "^8.0.0",
-    "mqemitter": "^4.4.0",
+    "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^14.0.3",
-    "standard": "^14.3.4",
+    "release-it": "^14.14.2",
+    "standard": "^16.0.4",
     "tape": "^4.13.3",
-    "tempy": "^0.7.1",
     "through2": "^4.0.2"
   },
   "dependencies": {
     "aedes-packet": "^2.3.1",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^5.0.3"
+    "qlobber": "^6.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -2,10 +2,20 @@ const test = require('tape').test
 const persistence = require('./')
 const abs = require('aedes-persistence/abstract')
 const { Level } = require('level') // Level >= 8.0.0
-const tempy = require('tempy')
+
+const { randomUUID } = require('crypto')
+const { tmpdir } = require('os')
+const { join } = require('path')
+const { mkdirSync } = require('fs')
+
+function tempDir () {
+  const dir = join(tmpdir(), 'aedes-persistence-level-test', randomUUID())
+  mkdirSync(dir, { recursive: true })
+  return dir
+}
 
 function leveldb () {
-  return new Level(tempy.directory())
+  return new Level(tempDir())
 }
 
 abs({


### PR DESCRIPTION
This PR updates all dependencies to the latest version except for 2:
- tempy: tempy is an ESM only module which makes it more cumbersome to import from CJS. Tempy has been removed as a dependency and replaced by native code.
- tape: on tape 4.13.3 all tests succeed but on 5.5.3 some tests fail because of the difference between an instance of Packet and a raw object with the same properties as the instance. The outgoing stream delivers raw objects on 8.0.0 just as on previous versions. It seems that `deepEqual` behaves differently between tape 4 and tape 5. 

