### PR TITLE
chore: upgrade to standardjs 17 and private class members

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
     "release-it": "^14.14.2",
-    "standard": "^16.0.4",
+    "standard": "^17.0.0",
     "tape": "^4.13.3",
     "through2": "^4.0.2"
   },


### PR DESCRIPTION
Standardjs 17 has just been released and now supports ECMA script standard [private class features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) (starting with '#')
This PR updates the dependency and updates the code to use ECMA script standard private class members.

Kind regards,
Hans