### PR TITLE
fix: prepare for persistence of more subscription properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/mcollina/aedes-persistence-level#readme",
   "devDependencies": {
     "aedes": "^0.46.3",
-    "aedes-persistence": "^9.0.3",
+    "aedes-persistence": "^9.1.1",
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
     "level": "^8.0.0",
@@ -60,6 +60,6 @@
   "dependencies": {
     "aedes-packet": "^3.0.0",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^6.0.0"
+    "qlobber": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,13 +52,13 @@
     "level": "^8.0.0",
     "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^14.14.2",
+    "release-it": "^15.0.0",
     "standard": "^17.0.0",
-    "tape": "^4.13.3",
+    "tape": "^5.5.3",
     "through2": "^4.0.2"
   },
   "dependencies": {
-    "aedes-packet": "^2.3.1",
+    "aedes-packet": "^3.0.0",
     "msgpack-lite": "^0.1.26",
     "qlobber": "^6.0.0"
   }

--- a/persistence.js
+++ b/persistence.js
@@ -58,6 +58,7 @@ async function * retainedMessagesByPattern (db, pattern) {
 async function subscriptionsByClient (db, client) {
   const resubs = []
   for await (const sub of decodedDbValues(db, subByClientKey(client.id))) {
+    // remove clientId from sub
     const { clientId, ...resub } = sub
     resubs.push(resub)
   }

--- a/persistence.js
+++ b/persistence.js
@@ -1,7 +1,7 @@
-const Qlobber = require('qlobber').Qlobber
+const { Qlobber } = require('qlobber')
 const Packet = require('aedes-packet')
 const msgpack = require('msgpack-lite')
-const EventEmitter = require('events').EventEmitter
+const { EventEmitter } = require('events')
 const { Readable } = require('stream')
 
 const QlobberOpts = {

--- a/persistence.js
+++ b/persistence.js
@@ -204,7 +204,7 @@ class LevelPersistence extends EventEmitter {
     }
 
     const opArray = []
-    subs.forEach((subscription) => {
+    for (const subscription of subs) {
       const sub = Object.assign({}, subscription)
       sub.clientId = client.id
       addSubToTrie(this.#trie, sub)
@@ -214,7 +214,7 @@ class LevelPersistence extends EventEmitter {
         value: msgpack.encode(sub)
       }
       opArray.push(ops)
-    })
+    }
     this.#dbBatch(opArray, (err) => {
       cb(err, client)
     })
@@ -222,7 +222,7 @@ class LevelPersistence extends EventEmitter {
 
   removeSubscriptions (client, topics, cb) {
     const opArray = []
-    topics.forEach((topic) => {
+    for (const topic of topics) {
       const sub = {
         clientId: client.id,
         topic
@@ -233,7 +233,7 @@ class LevelPersistence extends EventEmitter {
         key: toSubKey(sub)
       }
       opArray.push(ops)
-    })
+    }
     this.#dbBatch(opArray, (err) => {
       cb(err, client)
     })

--- a/persistence.js
+++ b/persistence.js
@@ -1,8 +1,8 @@
-const { Qlobber } = require('qlobber')
 const Packet = require('aedes-packet')
 const msgpack = require('msgpack-lite')
 const { EventEmitter } = require('events')
 const { Readable } = require('stream')
+const QlobberSub = require('qlobber/aedes/qlobber-sub')
 const { QlobberTrue } = require('qlobber')
 
 const QlobberOpts = {
@@ -140,7 +140,7 @@ class LevelPersistence extends EventEmitter {
   constructor (db) {
     super()
     this.#db = db
-    this.#trie = new Qlobber(QlobberOpts)
+    this.#trie = new QlobberSub(QlobberOpts)
     this.#ready = false
 
     const that = this

--- a/persistence.js
+++ b/persistence.js
@@ -3,6 +3,7 @@ const Packet = require('aedes-packet')
 const msgpack = require('msgpack-lite')
 const { EventEmitter } = require('events')
 const { Readable } = require('stream')
+const { QlobberTrue } = require('qlobber')
 
 const QlobberOpts = {
   wildcard_one: '+',
@@ -44,11 +45,11 @@ async function loadSubscriptions (db, trie) {
 }
 
 async function * retainedMessagesByPattern (db, pattern) {
-  const qlobber = new Qlobber(QlobberOpts)
-  qlobber.add(pattern, true)
+  const qlobber = new QlobberTrue(QlobberOpts)
+  qlobber.add(pattern)
 
   for await (const packet of decodedDbValues(db, RETAINED)) {
-    if (qlobber.match(packet.topic).length) {
+    if (qlobber.test(packet.topic)) {
       yield packet
     }
   }

--- a/persistence.js
+++ b/persistence.js
@@ -135,7 +135,6 @@ class LevelPersistence extends EventEmitter {
   #db
   #trie
   #ready
-  #keyPadLength
 
   constructor (db) {
     super()
@@ -143,7 +142,6 @@ class LevelPersistence extends EventEmitter {
     this.#trie = new Qlobber(QlobberOpts)
     this.#ready = false
 
-    this.#keyPadLength = 16
     const that = this
 
     loadSubscriptions(this.#db, this.#trie)

--- a/test.js
+++ b/test.js
@@ -51,11 +51,17 @@ test('restore', t => {
       t.deepEqual(resubs, [{
         clientId: client.id,
         topic: 'hello/#',
-        qos: 1
+        qos: 1,
+        rh: undefined,
+        rap: undefined,
+        nl: undefined
       }, {
         clientId: client.id,
         topic: 'hello',
-        qos: 1
+        qos: 1,
+        rh: undefined,
+        rap: undefined,
+        nl: undefined
       }])
       instance.destroy(t.end.bind(t))
     })
@@ -131,11 +137,17 @@ test('Dont replace subscriptions with different QoS if client id is different', 
         t.deepEqual(resubs, [{
           topic: 'test/television/dev/about',
           clientId: 'test.1',
-          qos: 1
+          qos: 1,
+          rh: undefined,
+          rap: undefined,
+          nl: undefined
         }, {
           topic: 'test/+/dev/#',
           clientId: 'test',
-          qos: 2
+          qos: 2,
+          rh: undefined,
+          rap: undefined,
+          nl: undefined
         }])
         instance.destroy(t.end.bind(t))
       })
@@ -169,7 +181,10 @@ test('Replace subscriptions with different QoS if client id is same', t => {
         t.deepEqual(resubs, [{
           topic: 'test/television/dev/about',
           clientId: 'test',
-          qos: 1
+          qos: 1,
+          rh: undefined,
+          rap: undefined,
+          nl: undefined
         }])
         instance.destroy(t.end.bind(t))
       })


### PR DESCRIPTION
As discussed in https://github.com/moscajs/aedes-persistence/pull/87

This PR does not break anything and should be compatible with new versions of `qlobber` and `aedes-persistence`
Final testing will need to wait until the new versions of `qlobber` and `aedes-persistence` are available.

While at it, I also reworked some other parts to make them more readable. The commit messages should explain themselves.

Kind regards,
Hans