### PR TITLE
chore: modernize dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, '*']
+        node-version: ['lts/-1', 'lts/*', 'node']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ node_modules
 mydb
 
 package-lock.json
+.tap/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The first parameter is an instance of [levelup][levelup].
 Example:
 
 ```js
-const { Level } = require('level') // Level >= 8.0.0 is required 
+const { Level } = require('level') // Level >= 9.0.0 is required 
 const aedesPersistencelevel = require('aedes-persistence-level')
 
 // instantiate a persistence instance

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "test": "standard && tape test.js | faucet",
+    "test": "standard && tap test.js",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
   },
   "release-it": {
@@ -45,21 +45,17 @@
   },
   "homepage": "https://github.com/mcollina/aedes-persistence-level#readme",
   "devDependencies": {
-    "aedes": "^0.46.3",
-    "aedes-persistence": "^9.1.1",
-    "concat-stream": "^2.0.0",
-    "faucet": "0.0.1",
+    "aedes": "^0.51.3",
+    "aedes-persistence": "^9.1.2",
     "level": "^9.0.0",
-    "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^15.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.5.3",
-    "through2": "^4.0.2"
+    "release-it": "^18.1.2",
+    "standard": "^17.1.2",
+    "tap": "^21.1.0"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^7.0.0"
+    "qlobber": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
   },
   "homepage": "https://github.com/mcollina/aedes-persistence-level#readme",
   "devDependencies": {
+    "@fastify/pre-commit": "^2.2.0",
     "aedes": "^0.51.3",
     "aedes-persistence": "^9.1.2",
     "level": "^9.0.0",
-    "pre-commit": "^1.2.2",
     "release-it": "^18.1.2",
     "standard": "^17.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "test": "standard && tap test.js",
+    "test": "standard && tape test.js | faucet",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
   },
   "release-it": {
@@ -50,12 +50,13 @@
     "level": "^8.0.0",
     "pre-commit": "^1.2.2",
     "release-it": "^18.1.2",
-    "standard": "^17.1.2",
-    "tap": "^21.1.0"
+    "standard": "^17.1.2"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
+    "faucet": "^0.0.4",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^8.0.1"
+    "qlobber": "^8.0.1",
+    "tape": "^5.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "aedes-persistence": "^9.1.1",
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
-    "level": "^8.0.0",
+    "level": "^9.0.0",
     "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
     "release-it": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "test": "standard && tape test.js | faucet",
+    "test": "standard && tap test.js",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
   },
   "release-it": {
@@ -45,21 +45,17 @@
   },
   "homepage": "https://github.com/mcollina/aedes-persistence-level#readme",
   "devDependencies": {
-    "aedes": "^0.46.3",
-    "aedes-persistence": "^9.1.1",
-    "concat-stream": "^2.0.0",
-    "faucet": "0.0.1",
+    "aedes": "^0.51.3",
+    "aedes-persistence": "^9.1.2",
     "level": "^8.0.0",
-    "mqemitter": "^4.5.0",
     "pre-commit": "^1.2.2",
-    "release-it": "^15.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.5.3",
-    "through2": "^4.0.2"
+    "release-it": "^18.1.2",
+    "standard": "^17.1.2",
+    "tap": "^21.1.0"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^7.0.0"
+    "qlobber": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=14.0.0"
   },
   "scripts": {
-    "test": "standard && tap test.js",
+    "test": "standard && tape test.js | faucet",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
   },
   "release-it": {
@@ -50,12 +50,13 @@
     "level": "^9.0.0",
     "pre-commit": "^1.2.2",
     "release-it": "^18.1.2",
-    "standard": "^17.1.2",
-    "tap": "^21.1.0"
+    "standard": "^17.1.2"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
+    "faucet": "^0.0.4",
     "msgpack-lite": "^0.1.26",
-    "qlobber": "^8.0.1"
+    "qlobber": "^8.0.1",
+    "tape": "^5.9.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const test = require('tape').test
+const { test } = require('tape')
 const persistence = require('./')
 const abs = require('aedes-persistence/abstract')
 const { Level } = require('level') // Level >= 8.0.0


### PR DESCRIPTION
This PR modernizes dependencies:
- CI now uses recent versions of both NodeJS and the Github actions used during CI.
- `qlobber`, `aedes` and `aedes-persistence` have been updated to their latest versions
- `concat-stream` , `mqemitter` and `through2` were not used

Mind you: `pre-commit` still gives 2 "High" warnings on `npm audit` and the module seems to be abandoned. So you might want to remove this as well.

Kind regards,
Hans