### PR TITLE
fix: make aedes-persistence a prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "aedes": "^0.51.3",
-    "aedes-persistence": "^10.2.0",
     "c8": "^10.1.3",
     "eslint": "^9.27.0",
     "level": "^10.0.0",
@@ -61,6 +60,7 @@
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
+    "aedes-persistence": "^10.2.0",
     "msgpack-lite": "^0.1.26",
     "qlobber": "^8.0.1"
   }


### PR DESCRIPTION
`aedes-persistence` was listed as a dev dependency which normally does not get installed if its a subdependency.
This resulted in an error on a clean prod installation as `aedes-persistence/callBackPersistence.js` could not be found.
This PR moves `aedes-persistence` from dev dependency to prod dependency.

Kind regards,
Hans