### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
     "@fastify/pre-commit": "^2.2.0",
     "aedes": "^0.51.3",
     "c8": "^10.1.3",
-    "eslint": "^9.27.0",
+    "eslint": "^9.30.1",
     "level": "^10.0.0",
-    "neostandard": "^0.12.1",
+    "neostandard": "^0.12.2",
     "release-it": "^19.0.3"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
-    "aedes-persistence": "^10.2.1",
+    "aedes-persistence": "^10.2.2",
     "msgpack-lite": "^0.1.26",
     "qlobber": "^8.0.1"
   }


### PR DESCRIPTION
This PR updates:

- aedes-persistence  ^10.2.1  →  ^10.2.2
- eslint             ^9.27.0  →  ^9.30.1
- neostandard        ^0.12.1  →  ^0.12.2
